### PR TITLE
Fix Link to Notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ See [README_TRAINING.md](README_TRAINING.md) for instructions on how to train 4M
 
 ### Generation
 
-See [README_GENERATION.md](README_GENERATION.md) for instructions on how to use 4M models for inference / generation. We also provide a [generation notebook](notebooks/generation.ipynb) that contains examples for 4M inference, specifically performing conditional image generation and common vision tasks (i.e. RGB-to-All).
+See [README_GENERATION.md](README_GENERATION.md) for instructions on how to use 4M models for inference / generation. We also provide a [generation notebook](notebooks/generation_4M-21.ipynb) that contains examples for 4M inference, specifically performing conditional image generation and common vision tasks (i.e. RGB-to-All).
 
 
 ## Model Zoo


### PR DESCRIPTION
https://github.com/apple/ml-4m?tab=readme-ov-file#generation currently links to https://github.com/apple/ml-4m/blob/main/notebooks/generation.ipynb which results in a 404.

There are 2 notebooks in the folder. I used the bigger model.