### PR TITLE
Update demo_4M_sampler.py

### DIFF
--- a/fourm/demo_4M_sampler.py
+++ b/fourm/demo_4M_sampler.py
@@ -258,6 +258,8 @@ class Demo4MSampler(nn.Module):
             self.mods_sr = mods_sr or list(set(fm_sr.encoder_modalities) | set(fm_sr.decoder_modalities))
         else:
             self.sampler_fm_sr = None
+            self.mods_sr = []
+
 
         # Load tokenizers
         self.toks = {}


### PR DESCRIPTION
fix bug: attribute error when Demo4MSampler is called with fm_sr=None and mod=mods_list with mods_list only subset of all.